### PR TITLE
Fix example to demonstrate several compressions

### DIFF
--- a/docs/src/pages/docs/size-limit.mdx
+++ b/docs/src/pages/docs/size-limit.mdx
@@ -44,7 +44,7 @@ To check several compression, just add a rule with a specific compression. The f
     {
       "test": "*.js",
       "maxSize": "10 kB",
-      "compression": "none"
+      "compression": "gzip"
     }
   ]
 }


### PR DESCRIPTION
Makes the example match the description: 'The following rule will check all JS file without compression and with "gzip" compression'